### PR TITLE
Modify compliant and non-compliant examples of typescript/server-side-request-forgery@v1.0 and typescript/cross-site-scripting@v1.0

### DIFF
--- a/src/typescript/detector/high/cross-site-scripting/cross-site-scripting.ts
+++ b/src/typescript/detector/high/cross-site-scripting/cross-site-scripting.ts
@@ -1,19 +1,21 @@
 // {fact rule=cross-site-scripting@v1.0 defects=1}
 function crossSiteScriptingNoncompliant() {
-  let url = window.location.search.slice(1);
+  let url = window.location.search.slice(1)
+
   // Noncompliant: unsafe jQuery ajax request.
-  $.ajax({ url: url, data: "Hello" });
+  $.ajax({url: url, data: "Hello"})
 }
 // {/fact}
 
 // {fact rule=cross-site-scripting@v1.0 defects=0}
-const ESAPI = require("node-esapi");
+import ESAPI from 'node-esapi'
 
 function crossSiteScriptingCompliant() {
-  let url = window.location.search.slice(1);
-  // Compliant: url is sanitized before ajax call.
-  url = ESAPI.encoder().encodeForURL(url);
-  $.ajax({ url: url, data: "Hello" });
-}
+  let url = window.location.search.slice(1)
 
+  // Compliant: url is sanitized before ajax call.
+  url = ESAPI.encoder().encodeForURL(url)
+
+  $.ajax({url: url, data: "Hello"})
+}
 // {/fact}

--- a/src/typescript/detector/high/server-side-request-forgery/server-side-request-forgery.ts
+++ b/src/typescript/detector/high/server-side-request-forgery/server-side-request-forgery.ts
@@ -1,24 +1,29 @@
 // {fact rule=server-side-request-forgery@v1.0 defects=1}
-var express = require("express");
-var app = express();
-var request = require("request");
+import express, { Request, Response } from 'express'
+import request from 'request'
+var app = express()
 
 function serverSideRequestForgeryNoncompliant() {
-  app.get("/data/img", (req: { body: { imageUrl: any } }, res: any) => {
-    var url = req.body.imageUrl;
+  app.get('/data/img', (req: Request, res: Response) => {
+    var url = req.body.imageUrl
+
     // Noncompliant: user provided url is used to make a request.
-    request.get(url);
+    request.get(url)
   });
 }
 // {/fact}
 
 // {fact rule=server-side-request-forgery@v1.0 defects=0}
+import express, { Request, Response } from 'express'
+import request from 'request'
+var app = express()
 
-var libxmljs = require("libxmljs");
-var fs = require("fs");
-function xmlExternalEntityCompliant() {
-  const xml = fs.readFileSync("foo.xml");
-  // Compliant: parsing of external entities is disabled by default.
-  const xmlDoc = libxmljs.parseXml(xml, { noblanks: true });
+function serverSideRequestForgeryCompliant() {
+  app.get('/data/img', (req: Request, res: Response) => {
+    // Compliant: url used to make a request is not user provided.
+    var url = 'https://example.com'
+
+    request.get(url)
+  })
 }
 // {/fact}


### PR DESCRIPTION
**Description of Changes**

1. Replace `require` like imports with `import` wherever possible. For example: `require("express")` becomes `import express from "express"`
2. Add import for `Request` and `Response` types and use them while to qualify the `req` and `res` objects in HTTP request handlers.
3. Remove semicolon `;` at the end of statments.

