### PR TITLE
Modify compliant and non-compliant examples of typescript/sql-injecti…

### DIFF
--- a/src/typescript/detector/high/cross-site-request-forgery/cross-site-request-forgery.ts
+++ b/src/typescript/detector/high/cross-site-request-forgery/cross-site-request-forgery.ts
@@ -1,56 +1,27 @@
 // {fact rule=cross-site-request-forgery@v1.0 defects=1}
-var express = require("express");
-var app = express();
+import express, { Request, Response } from 'express'
+var app = express()
+
 function crossSiteRequestForgeryNoncompliant() {
-  app.get(
-    "/",
-    (
-      req: any,
-      res: {
-        cookie: (
-          arg0: string,
-          arg1: string,
-          arg2: { sameSite: string; secure: boolean },
-        ) => void;
-        render: (arg0: string) => void;
-      },
-    ) => {
-      // Noncompliant: `sameSite` is set to 'none'.
-      res.cookie("cookieName", "cookieValue", {
-        sameSite: "none",
-        secure: true,
-      });
-      res.render("index.html");
-    },
-  );
+    app.get("/", (req: Request, res: Response) => {
+        // Noncompliant: `sameSite` is set to 'none'.
+        res.cookie('cookieName', 'cookieValue', { sameSite: 'none', secure: true })
+        res.render("index.html")
+    })
 }
 // {/fact}
 
-// {fact rule=cross-site-request-forgery@v1.0 defects=0}
 
-var express = require("express");
-var app = express();
+// {fact rule=cross-site-request-forgery@v1.0 defects=0}
+import express, { Request, Response } from 'express'
+var app = express()
+
 function crossSiteRequestForgeryCompliant() {
-  app.get(
-    "/",
-    (
-      req: any,
-      res: {
-        cookie: (
-          arg0: string,
-          arg1: string,
-          arg2: { sameSite: string; secure: boolean },
-        ) => void;
-        render: (arg0: string) => void;
-      },
-    ) => {
-      // Compliant: `sameSite` is set to 'lax'.
-      res.cookie("cookieName", "cookieValue", {
-        sameSite: "lax",
-        secure: true,
-      });
-      res.render("index.html");
-    },
-  );
+    app.get("/", (req: Request, res: Response) => {
+        // Compliant: `sameSite` is set to 'lax'.
+        res.cookie('cookieName', 'cookieValue', { sameSite: 'lax', secure: true })
+
+        res.render("index.html")
+    })
 }
 // {/fact}

--- a/src/typescript/detector/high/sql-injection/sql-injection.ts
+++ b/src/typescript/detector/high/sql-injection/sql-injection.ts
@@ -1,47 +1,48 @@
 // {fact rule=sql-injection@v1.0 defects=1}
-var sql = require("mysql");
-var express = require("express");
-var app = express();
+import sql from 'mysql'
+import express, { Request, Response } from 'express'
+var app = express()
 
 var connection = sql.createConnection({
-  host: "localhost",
-  user: "myUserName",
-  password: "myPass",
-  database: "myDatabase",
-});
+    host     : 'localhost',
+    user     : 'myUserName',
+    password : 'myPass',
+    database : 'myDatabase'
+})
 
 function sqlInjectionNoncompliant() {
-  app.get("/user/:id", (req: { params: { id: string } }, res: any) => {
-    // Noncompliant: user input is not sanitized before use.
-    var query = "SELECT * FROM Employees WHERE ID = " + req.params.id;
-    connection.query(query, (error: any, results: any, fields: any) => {
-      if (error) throw error;
-    });
-  });
+    app.get("/user/:id", (req: Request, res: Response) => {
+        // Noncompliant: user input is not sanitized before use.
+        var query = "SELECT * FROM Employees WHERE ID = " + req.params.id
+
+        connection.query(query, (error: any, results: any, fields: any) => {
+            if (error) throw error
+        })
+    })
 }
 // {/fact}
 
+
 // {fact rule=sql-injection@v1.0 defects=0}
-var sql = require("mysql");
-var express = require("express");
-var app = express();
+import sql from 'mysql'
+import express, { Request, Response } from 'express'
+var app = express()
 
 var connection = sql.createConnection({
-  host: "localhost",
-  user: "myUserName",
-  password: "myPass",
-  database: "myDatabase",
+    host     : 'localhost',
+    user     : 'myUserName',
+    password : 'myPass',
+    database : 'myDatabase'
 });
 
 function sqlInjectionCompliant() {
-  app.get("/user/:id", (req: { params: { id: any } }, res: any) => {
-    // Compliant: user input is sanitized before use.
-    var query =
-      "SELECT * FROM Employees WHERE ID = " + connection.escape(req.params.id);
-    connection.query(query, (error: any, results: any, fields: any) => {
-      if (error) throw error;
-    });
-  });
-}
+    app.get("/user/:id", (req: Request, res: Response) => {
+        // Compliant: user input is sanitized before use.
+        var query = "SELECT * FROM Employees WHERE ID = " + connection.escape(req.params.id)
 
+        connection.query(query, (error: any, results: any, fields: any) => {
+            if (error) throw error
+        })
+    })
+}
 // {/fact}

--- a/src/typescript/detector/high/xml-external-entity/xml-external-entity.ts
+++ b/src/typescript/detector/high/xml-external-entity/xml-external-entity.ts
@@ -1,24 +1,22 @@
 // {fact rule=xml-external-entity@v1.0 defects=1}
-var libxmljs = require("libxmljs");
-var fs = require("fs");
+import libxmljs from "libxmljs"
+import fs from 'fs'
+
 function xmlExternalEntityNoncompliant() {
-  const xml = fs.readFileSync("foo.xml");
-  // Noncompliant: sets `noent` to true which enables the parsing of external entities.
-  const xmlDoc = libxmljs.parseXml(xml, { noent: true, noblanks: true });
+    const xml = fs.readFileSync("foo.xml")
+    // Noncompliant: sets `noent` to true which enables the parsing of external entities.
+    const xmlDoc = libxmljs.parseXml(xml, { noent: true, noblanks: true })
 }
 // {/fact}
 
+
 // {fact rule=xml-external-entity@v1.0 defects=0}
+import libxmljs from "libxmljs"
+import fs from 'fs'
 
-var express = require("express");
-var app = express();
-var request = require("request");
-
-function serverSideRequestForgeryCompliant() {
-  app.get("/data/img", (req: any, res: any) => {
-    // Compliant: url used to make a request is not user provided.
-    var url = "https://example.com";
-    request.get(url);
-  });
+function xmlExternalEntityCompliant() {
+    const xml = fs.readFileSync("foo.xml")
+    // Compliant: parsing of external entities is disabled by default.
+    const xmlDoc = libxmljs.parseXml(xml, { noblanks: true })
 }
 // {/fact}


### PR DESCRIPTION
Description of Changes

1. Replace require like imports with import wherever possible. For example: require("express") becomes import express from "express"
2. Add import for Request and Response types and use them while to qualify the req and res objects in HTTP request handlers.
3. Remove semicolon ; at the end of statements.