### PR TITLE
Modify compliant and non-compliant examples of typescript/insufficiently-protected-credentials@v1.0 , typescript/integer-overflow@v1.0, typescript/least-privilege-violation@v1.0

### DIFF
--- a/src/typescript/detector/medium/insecure-hashing/insecure-hashing.ts
+++ b/src/typescript/detector/medium/insecure-hashing/insecure-hashing.ts
@@ -1,19 +1,17 @@
 // {fact rule=insecure-hashing@v1.0 defects=1}
-
+import crypto from 'crypto'
 function insecureHashingNoncompliant() {
-  var crypto = require("crypto");
   // Noncompliant: 'md5' is weak hash algorithm.
-  var insecure_hash_algo = "md5";
-  crypto.createHash(insecure_hash_algo);
+  var insecure_hash_algo = 'md5'
+  crypto.createHash(insecure_hash_algo)
 }
-//{/fact}
+// {/fact}
 
 // {fact rule=insecure-hashing@v1.0 defects=0}
-
+import crypto from 'crypto'
 function insecureHashingCompliant() {
-  var crypto = require("crypto");
   // Compliant: 'SHA-256' is secure hash algorithm.
-  var secure_hash_algo = "SHA-256";
-  crypto.createHash(secure_hash_algo);
+  var secure_hash_algo = 'SHA-256'
+  crypto.createHash(secure_hash_algo)
 }
-//{/fact}
+// {/fact}

--- a/src/typescript/detector/medium/insecure-object-attribute-modification/insecure-object-attribute-modification.ts
+++ b/src/typescript/detector/medium/insecure-object-attribute-modification/insecure-object-attribute-modification.ts
@@ -1,45 +1,26 @@
-// {fact rule=insecur-object-attribute-modification@v1.0 defects=1}
-var express = require("express");
-var app = express();
+// {fact rule=insecure-object-attribute-modification@v1.0 defects=1}
+import express, {Request, Response} from 'express'
+var app = express()
 function insecureObjectAttributeModificationNoncompliant() {
-  app.get(
-    "www.example.com",
-    (
-      req: {
-        params: { id: any };
-        session: { user: { [x: string]: any } };
-        body: { [x: string]: any };
-      },
-      res: any,
-    ) => {
-      var userId = req.params.id;
-      // Noncompliant: external input used as object property.
-      req.session.user[userId] = req.body["userDetails"];
-    },
-  );
+    app.get('www.example.com', (req: Request, res: Response) => {
+        var userId = req.params.id
+        // Noncompliant: external input used as object property.
+        req.session.user[userId] = req.body['userDetails']
+    });
 }
 // {/fact}
 
-// {fact rule=insecur-object-attribute-modification@v1.0 defects=0}
-var express = require("express");
-var app = express();
+
+// {fact rule=insecure-object-attribute-modification@v1.0 defects=0}
+import express, {Request, Response} from 'express'
+var app = express()
 function insecureObjectAttributeModificationCompliant() {
-  app.get(
-    "www.example.com",
-    (
-      req: {
-        params: { id: any };
-        session: { user: { [x: string]: any } };
-        body: { [x: string]: any };
-      },
-      res: any,
-    ) => {
-      var userId = req.params.id;
-      // Compliant: checks the type of userId as string.
-      if (typeof userId === "string") {
-        req.session.user[userId] = req.body["userDetails"];
-      }
-    },
-  );
+    app.get('www.example.com', (req: Request, res: Response) => {
+        var userId = req.params.id
+        // Compliant: checks the type of userId as string.
+        if (typeof userId === 'string') {
+            req.session.user[userId] = req.body['userDetails']
+        }
+    });
 }
 // {/fact}

--- a/src/typescript/detector/medium/insecure-temporary-file-or-directory/insecure-temporary-file-or-directory.ts
+++ b/src/typescript/detector/medium/insecure-temporary-file-or-directory/insecure-temporary-file-or-directory.ts
@@ -1,22 +1,20 @@
-// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=1}
-var fs = require("fs");
-
+// {fact rule=insecure-temp-file@v1.0 defects=1}
+import fs from 'fs'
 function insecureTempFileNoncompliant() {
   // Noncompliant: the global directory path is given for opening a file or creating a file which can be vulnerable to injection attacks.
-  var tmp_file = "/tmp/f";
-  fs.readFile(tmp_file, "utf8", function (err: any, data: any) {
+  var tmp_file : string = "/tmp/f"
+  fs.readFile(tmp_file, 'utf8', function (err: any, data: any) {
     // ...
-  });
+  })
 }
-//{/fact}
+// {/fact}
 
-// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=0}
-var fs = require("fs");
-var tmp = require("tmp");
-
+// {fact rule=insecure-temp-file@v1.0 defects=0}
+import fs from 'fs'
+import tmp from 'tmp'
 function insecureTempFileCompliant() {
   // Compliant: tmp library to securely create or read temporary files.
-  var tmp_obj = tmp.fileSync();
-  fs.readFile(tmp_obj, "utf8");
+  var tmp_obj = tmp.fileSync()
+  fs.readFile(tmp_obj, 'utf8')
 }
-//{/fact}
+// {/fact}

--- a/src/typescript/detector/medium/insufficiently-protected-credentials/insufficiently-protected-credentials.ts
+++ b/src/typescript/detector/medium/insufficiently-protected-credentials/insufficiently-protected-credentials.ts
@@ -1,5 +1,5 @@
 // {fact rule=insufficiently-protected-credentials@v1.0 defects=1}
-var jwt = require("jsonwebtoken");
+import * as jwt from 'jsonwebtoken'
 class Users {
   constructor() {}
 
@@ -7,8 +7,6 @@ class Users {
 }
 
 function insufficientlyProtectedCredentialsNoncompliant() {
-  var req: any, key: any;
-  var User = new Users();
   User.findOne({ email: req.body.email }, function (e: any, user: any) {
     // Noncompliant: object is passed directly to `jsonwebtoken.sign()`.
     var token = jwt.sign(user, key, { expiresIn: 60 * 60 * 10 });
@@ -18,7 +16,7 @@ function insufficientlyProtectedCredentialsNoncompliant() {
 //{/fact}
 
 // {fact rule=insufficiently-protected-credentials@v1.0 defects=0}
-var jwt = require("jsonwebtoken");
+import * as jwt from 'jsonwebtoken'
 
 function insufficientlyProtectedCredentialsCompliant() {
   var req: any, key: any;

--- a/src/typescript/detector/medium/integer-overflow/integer-overflow.ts
+++ b/src/typescript/detector/medium/integer-overflow/integer-overflow.ts
@@ -1,7 +1,7 @@
 // {fact rule=integer-overflow@v1.0 defects=1}
 function integerOverflowNoncompliant() {
   // Noncompliant: bigint is assigned to a variable.
-  var max = 154327115334273650000012748329;
+  var max: number = 154327115334273650000012748329;
 }
 //{/fact}
 

--- a/src/typescript/detector/medium/least-privilege-violation/least-privilege-violation.ts
+++ b/src/typescript/detector/medium/least-privilege-violation/least-privilege-violation.ts
@@ -1,5 +1,5 @@
 // {fact rule=least-privilege-violation@v1.0 defects=1}
-var { BrowserWindow } = require("electron");
+import { BrowserWindow } from 'electron'
 
 function leastPrivilegeViolationNoncompliant() {
   var win = new BrowserWindow({
@@ -15,7 +15,7 @@ function leastPrivilegeViolationNoncompliant() {
 // {/fact}
 
 // {fact rule=least-privilege-violation@v1.0 defects=0}
-var { BrowserWindow } = require("electron");
+import { BrowserWindow } from 'electron'
 function leastPrivilegeViolationCompliant() {
   var win = new BrowserWindow({
     width: 800,


### PR DESCRIPTION
**Changes**

1. Replace `require(..) `syntax with `import` statements.
2. Use the `Request` and `Response` objects in `express` wherever possible