### PR TITLE
Modify compliant and non-compliant examples of typescript/new-function-detected@v1.0, typescript/non-literal-regular-expression@v1.0, typescript/nosql-injection@v1.0

### DIFF
--- a/src/typescript/detector/high/logging-of-sensitive-information/logging-of-sensitive-information.ts
+++ b/src/typescript/detector/high/logging-of-sensitive-information/logging-of-sensitive-information.ts
@@ -1,5 +1,5 @@
 // {fact rule=logging-of-sensitive-information@v1.0 defects=1}
-var { Signale } = require("signale");
+import { Signale } from 'signale'
 
 function loggingOfSensitiveInformationNoncompliant() {
   var options = {
@@ -17,7 +17,7 @@ function loggingOfSensitiveInformationNoncompliant() {
 // {/fact}
 
 // {fact rule=logging-of-sensitive-information@v1.0 defects=0}
-var { Signale } = require("signale");
+import { Signale } from 'signale'
 
 function loggingOfSensitiveInformationCompliant() {
   var options = {

--- a/src/typescript/detector/high/loose-file-permissions/loose-file-permissions.ts
+++ b/src/typescript/detector/high/loose-file-permissions/loose-file-permissions.ts
@@ -1,5 +1,5 @@
 // {fact rule=loose-file-permissions@v1.0 defects=1}
-var fs = require("fs");
+import fs from 'fs'
 function looseFilePermissionsNoncompliant() {
   // Noncompliant: read permissions assigned to others.
   fs.promises.chmod("/path", 0o774).then((r: any) => {});
@@ -7,7 +7,7 @@ function looseFilePermissionsNoncompliant() {
 // {/fact}
 
 // {fact rule=loose-file-permissions@v1.0 defects=0}
-var fs = require("fs");
+import fs from 'fs'
 function looseFilePermissionsCompliant() {
   // Compliant: read, write and execute permissions assigned to owner and no permission assigned to others.
   fs.promises.chmod("/path", 0o770).then((r: any) => {});

--- a/src/typescript/detector/high/non-literal-regular-expression/non-literal-regular-expression.ts
+++ b/src/typescript/detector/high/non-literal-regular-expression/non-literal-regular-expression.ts
@@ -1,8 +1,8 @@
 // {fact rule=non-literal-regular-expression@v1.0 defects=1}
-var express = require("express");
-var app = express();
+import express, {Request, Response} from 'express'
+var app = express()
 function nonLiteralRegularExpressionNoncompliant() {
-  app.get("www.example.com", (req: { body: { id: any } }, res: any) => {
+  app.get("www.example.com", (req: Request, res: Response) => {
     var re = new RegExp("ab+c");
     // Noncompliant: user-controlled data passes into `test` for regex patterns.
     var test = re.test(req.body.id);
@@ -12,11 +12,11 @@ function nonLiteralRegularExpressionNoncompliant() {
 
 // {fact rule=non-literal-regular-expression@v1.0 defects=0}
 
-var express = require("express");
-var escapeStringRegexp = require("escape-string-regexp");
-var app = express();
+import express, {Request, Response} from 'express'
+import escapeStringRegexp from 'escape-string-regexp'
+var app = express()
 function nonLiteralRegularExpressionCompliant() {
-  app.get("www.example.com", (req: { body: { id: any } }, res: any) => {
+  app.get("www.example.com", (req: Request, res: Response) => {
     var re = new RegExp("ab+c");
     // Compliant: sanitized user-controlled data passes into `test` for regex patterns.
     var test = re.test(escapeStringRegexp(req.body.id));

--- a/src/typescript/detector/high/nosql-injection/nosql-injection.ts
+++ b/src/typescript/detector/high/nosql-injection/nosql-injection.ts
@@ -1,80 +1,44 @@
 // {fact rule=nosql-injection@v1.0 defects=1}
-var AWS = require("aws-sdk");
-var express = require("express");
-var app = express();
+import * as AWS from 'aws-sdk'
+import express, {Request, Response} from 'express'
+var app = express()
 function noSqlInjectionNoncompliant() {
-  app.get(
-    "/api/getallusers",
-    function (req: { body: { params: any } }, res: any) {
-      var docClient = new AWS.DynamoDB.DocumentClient({ region: "us-east-1" });
-      var params = req.body.params;
-      // Noncompliant: external user input can be vulnerable to injection attacks.
-      docClient.scan(
-        params,
-        function (
-          err: any,
-          data: {
-            Items: {
-              forEach: (
-                arg0: (element: any, index: any, array: any) => void,
-              ) => void;
-            };
-          },
-        ) {
-          if (err) {
-            console.log("Error", err);
-          } else {
-            data.Items.forEach(function (
-              element: { Title: { S: string }; Subtitle: { S: string } },
-              index: any,
-              array: any,
-            ) {
-              console.log(element.Title.S + " (" + element.Subtitle.S + ")");
-            });
-          }
-        },
-      );
-    },
-  );
+    app.get('/api/getallusers', function(req: Request, res: Response) {
+        var docClient = new AWS.DynamoDB.DocumentClient({region: "us-east-1"});
+        var params= req.body.params
+        // Noncompliant: external user input can be vulnerable to injection attacks.
+        docClient.scan(params, function(err: any, data: { Items: any[]; }) {
+            if (err) {
+                console.log("Error", err)
+            } else {
+                data.Items.forEach(function(element: { Title: { S: string; }; Subtitle: { S: string; }; }, index: any, array: any) {
+                    console.log(element.Title.S + " (" + element.Subtitle.S + ")")
+                })
+            }
+        })
+    })
 }
 // {/fact}
 
 // {fact rule=nosql-injection@v1.0 defects=0}
-var AWS = require("aws-sdk");
-var express = require("express");
-var app = express();
+import * as AWS from 'aws-sdk'
+import express, {Request, Response} from 'express'
+var app = express()
 function noSqlInjectionCompliant() {
-  app.get(
-    "/api/getallusers",
-    function (
-      req: any,
-      res: {
-        status: (arg0: number) => {
-          (): any;
-          new (): any;
-          json: {
-            (arg0: { status: number; message: string; data: any }): void;
-            new (): any;
-          };
-        };
-      },
-    ) {
-      var docClient = new AWS.DynamoDB.DocumentClient({ region: "us-east-1" });
-      var params = {
-        TableName: "dynamodb-example-node",
-        ProjectionExpression: "user_id, username, user_age",
-      };
-      // Compliant: should not use external input in `scan` API.
-      docClient.scan(params, function (err: any, data: { Items: any }) {
-        if (err) {
-          console.log(err);
-        } else {
-          res
-            .status(200)
-            .json({ status: 1, message: "user exists", data: data.Items });
+    app.get('/api/getallusers', function (req: Request, res: Response) {
+        var docClient = new AWS.DynamoDB.DocumentClient({region: "us-east-1"});
+        var params = {
+            TableName: "dynamodb-example-node",
+            ProjectionExpression: "user_id, username, user_age",
         }
-      });
-    },
-  );
+        // Compliant: should not use external input in `scan` API.
+        docClient.scan(params, function (err: any, data: { Items: any; }) {
+            if (err) {
+                console.log(err)
+            } else {
+                res.status(200).json({ "status": 1, "message": "user exists", "data": data.Items })
+            }
+        })
+    })
 }
 // {/fact}

--- a/src/typescript/detector/low/limit-request-length/limit-request-length.ts
+++ b/src/typescript/detector/low/limit-request-length/limit-request-length.ts
@@ -1,7 +1,7 @@
 // {fact rule=limit-request-length@v1.0 defects=1}
-var express = require("express");
-var app = express();
-var bodyParser = require("body-parser");
+import express from 'express'
+var app = express()
+var bodyParser = require('body-parser')
 function limitOnRequestContentLengthNoncompliant() {
   // Noncompliant: limit on request content length is > 2mb in a requests.
   app.use(bodyParser.urlencoded({ extended: false, limit: "4mb" }));
@@ -9,9 +9,9 @@ function limitOnRequestContentLengthNoncompliant() {
 //{/fact}
 
 // {fact rule=limit-request-length@v1.0 defects=0}
-var express = require("express");
-var app = express();
-var bodyParser = require("body-parser");
+import express from 'express'
+var app = express()
+var bodyParser = require('body-parser')
 function limitOnRequestContentLengthCompliant() {
   // Compliant: limit on request content length is <= 2mb requests.
   app.use(bodyParser.urlencoded({ extended: false, limit: "1mb" }));

--- a/src/typescript/detector/medium/insecure-hashing/insecure-hashing.ts
+++ b/src/typescript/detector/medium/insecure-hashing/insecure-hashing.ts
@@ -1,19 +1,17 @@
 // {fact rule=insecure-hashing@v1.0 defects=1}
-
+import crypto from 'crypto'
 function insecureHashingNoncompliant() {
-  var crypto = require("crypto");
   // Noncompliant: 'md5' is weak hash algorithm.
-  var insecure_hash_algo = "md5";
-  crypto.createHash(insecure_hash_algo);
+  var insecure_hash_algo = 'md5'
+  crypto.createHash(insecure_hash_algo)
 }
-//{/fact}
+// {/fact}
 
 // {fact rule=insecure-hashing@v1.0 defects=0}
-
+import crypto from 'crypto'
 function insecureHashingCompliant() {
-  var crypto = require("crypto");
   // Compliant: 'SHA-256' is secure hash algorithm.
-  var secure_hash_algo = "SHA-256";
-  crypto.createHash(secure_hash_algo);
+  var secure_hash_algo = 'SHA-256'
+  crypto.createHash(secure_hash_algo)
 }
-//{/fact}
+// {/fact}

--- a/src/typescript/detector/medium/insecure-object-attribute-modification/insecure-object-attribute-modification.ts
+++ b/src/typescript/detector/medium/insecure-object-attribute-modification/insecure-object-attribute-modification.ts
@@ -1,45 +1,26 @@
-// {fact rule=insecur-object-attribute-modification@v1.0 defects=1}
-var express = require("express");
-var app = express();
+// {fact rule=insecure-object-attribute-modification@v1.0 defects=1}
+import express, {Request, Response} from 'express'
+var app = express()
 function insecureObjectAttributeModificationNoncompliant() {
-  app.get(
-    "www.example.com",
-    (
-      req: {
-        params: { id: any };
-        session: { user: { [x: string]: any } };
-        body: { [x: string]: any };
-      },
-      res: any,
-    ) => {
-      var userId = req.params.id;
-      // Noncompliant: external input used as object property.
-      req.session.user[userId] = req.body["userDetails"];
-    },
-  );
+    app.get('www.example.com', (req: Request, res: Response) => {
+        var userId = req.params.id
+        // Noncompliant: external input used as object property.
+        req.session.user[userId] = req.body['userDetails']
+    });
 }
 // {/fact}
 
-// {fact rule=insecur-object-attribute-modification@v1.0 defects=0}
-var express = require("express");
-var app = express();
+
+// {fact rule=insecure-object-attribute-modification@v1.0 defects=0}
+import express, {Request, Response} from 'express'
+var app = express()
 function insecureObjectAttributeModificationCompliant() {
-  app.get(
-    "www.example.com",
-    (
-      req: {
-        params: { id: any };
-        session: { user: { [x: string]: any } };
-        body: { [x: string]: any };
-      },
-      res: any,
-    ) => {
-      var userId = req.params.id;
-      // Compliant: checks the type of userId as string.
-      if (typeof userId === "string") {
-        req.session.user[userId] = req.body["userDetails"];
-      }
-    },
-  );
+    app.get('www.example.com', (req: Request, res: Response) => {
+        var userId = req.params.id
+        // Compliant: checks the type of userId as string.
+        if (typeof userId === 'string') {
+            req.session.user[userId] = req.body['userDetails']
+        }
+    });
 }
 // {/fact}

--- a/src/typescript/detector/medium/insecure-temporary-file-or-directory/insecure-temporary-file-or-directory.ts
+++ b/src/typescript/detector/medium/insecure-temporary-file-or-directory/insecure-temporary-file-or-directory.ts
@@ -1,22 +1,20 @@
-// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=1}
-var fs = require("fs");
-
+// {fact rule=insecure-temp-file@v1.0 defects=1}
+import fs from 'fs'
 function insecureTempFileNoncompliant() {
   // Noncompliant: the global directory path is given for opening a file or creating a file which can be vulnerable to injection attacks.
-  var tmp_file = "/tmp/f";
-  fs.readFile(tmp_file, "utf8", function (err: any, data: any) {
+  var tmp_file : string = "/tmp/f"
+  fs.readFile(tmp_file, 'utf8', function (err: any, data: any) {
     // ...
-  });
+  })
 }
-//{/fact}
+// {/fact}
 
-// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=0}
-var fs = require("fs");
-var tmp = require("tmp");
-
+// {fact rule=insecure-temp-file@v1.0 defects=0}
+import fs from 'fs'
+import tmp from 'tmp'
 function insecureTempFileCompliant() {
   // Compliant: tmp library to securely create or read temporary files.
-  var tmp_obj = tmp.fileSync();
-  fs.readFile(tmp_obj, "utf8");
+  var tmp_obj = tmp.fileSync()
+  fs.readFile(tmp_obj, 'utf8')
 }
-//{/fact}
+// {/fact}

--- a/src/typescript/detector/medium/insufficiently-protected-credentials/insufficiently-protected-credentials.ts
+++ b/src/typescript/detector/medium/insufficiently-protected-credentials/insufficiently-protected-credentials.ts
@@ -1,5 +1,5 @@
 // {fact rule=insufficiently-protected-credentials@v1.0 defects=1}
-var jwt = require("jsonwebtoken");
+import * as jwt from 'jsonwebtoken'
 class Users {
   constructor() {}
 
@@ -7,8 +7,6 @@ class Users {
 }
 
 function insufficientlyProtectedCredentialsNoncompliant() {
-  var req: any, key: any;
-  var User = new Users();
   User.findOne({ email: req.body.email }, function (e: any, user: any) {
     // Noncompliant: object is passed directly to `jsonwebtoken.sign()`.
     var token = jwt.sign(user, key, { expiresIn: 60 * 60 * 10 });
@@ -18,7 +16,7 @@ function insufficientlyProtectedCredentialsNoncompliant() {
 //{/fact}
 
 // {fact rule=insufficiently-protected-credentials@v1.0 defects=0}
-var jwt = require("jsonwebtoken");
+import * as jwt from 'jsonwebtoken'
 
 function insufficientlyProtectedCredentialsCompliant() {
   var req: any, key: any;

--- a/src/typescript/detector/medium/integer-overflow/integer-overflow.ts
+++ b/src/typescript/detector/medium/integer-overflow/integer-overflow.ts
@@ -1,7 +1,7 @@
 // {fact rule=integer-overflow@v1.0 defects=1}
 function integerOverflowNoncompliant() {
   // Noncompliant: bigint is assigned to a variable.
-  var max = 154327115334273650000012748329;
+  var max: number = 154327115334273650000012748329;
 }
 //{/fact}
 

--- a/src/typescript/detector/medium/least-privilege-violation/least-privilege-violation.ts
+++ b/src/typescript/detector/medium/least-privilege-violation/least-privilege-violation.ts
@@ -1,5 +1,5 @@
 // {fact rule=least-privilege-violation@v1.0 defects=1}
-var { BrowserWindow } = require("electron");
+import { BrowserWindow } from 'electron'
 
 function leastPrivilegeViolationNoncompliant() {
   var win = new BrowserWindow({
@@ -15,7 +15,7 @@ function leastPrivilegeViolationNoncompliant() {
 // {/fact}
 
 // {fact rule=least-privilege-violation@v1.0 defects=0}
-var { BrowserWindow } = require("electron");
+import { BrowserWindow } from 'electron'
 function leastPrivilegeViolationCompliant() {
   var win = new BrowserWindow({
     width: 800,

--- a/src/typescript/detector/medium/new-function-detected/new-function-detected.ts
+++ b/src/typescript/detector/medium/new-function-detected/new-function-detected.ts
@@ -1,8 +1,8 @@
 // {fact rule=new-function-detected@v1.0 defects=1}
-var express = require("express");
-var app = express();
+import express, {Request, Response} from 'express'
+var app = express()
 function newFunctionDetectedNoncompliant() {
-  app.post("www.example.com", (req: { body: any }, res: any) => {
+  app.post("www.example.com", (req : Request, res : Response) => {
     // Noncompliant: passing arbitrary user-input to new 'Function()'.
     var newFunc = new Function(req.body);
     newFunc();
@@ -11,10 +11,10 @@ function newFunctionDetectedNoncompliant() {
 //{/fact}
 
 // {fact rule=new-function-detected@v1.0 defects=0}
-var express = require("express");
-var app = express();
+import express, {Request, Response} from 'express'
+var app = express()
 function newFunctionDetectedCompliant() {
-  app.post("www.example.com", (req: any, res: any) => {
+  app.post("www.example.com", (req : Request, res : Response) => {
     var value = "test";
     // Compliant: passing hardcoded value to new 'Function()'.
     var newFunc = new Function("alert(value)");


### PR DESCRIPTION
**Changes**

1. Replace `require(..) `syntax with `import` statements.
2. Use the `Request` and `Response` objects in `express` wherever possible