### PR TITLE
Modify compliant and non-compliant examples of typescript/insecure-cryptography@v1.0, typescript/session-fixation@v1.0, typescript/improper-certificate-validation@v1.0, typescript/insecure-cookie@v1.0, typescript/improper-input-validation@v1.0, typescript/insecure-cors-policy@v1.0

### DIFF
--- a/src/typescript/detector/critical/insecure-cryptography/insecure-cryptography.ts
+++ b/src/typescript/detector/critical/insecure-cryptography/insecure-cryptography.ts
@@ -1,5 +1,5 @@
 // {fact rule=insecure-cryptography@v1.0 defects=1}
-var https = require("https");
+import https from 'https'
 function insecureCryptographyNoncompliant() {
   var ciphers = [
     `TLS_DH_anon_WITH_AES_256_GCM_SHA384`,
@@ -28,7 +28,7 @@ function insecureCryptographyNoncompliant() {
 // {/fact}
 
 // {fact rule=insecure-cryptography@v1.0 defects=0}
-var https = require("https");
+import https from 'https'
 function insecureCryptographyCompliant() {
   var ciphers = [
     `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`,

--- a/src/typescript/detector/critical/session_fixation/session_fixation.ts
+++ b/src/typescript/detector/critical/session_fixation/session_fixation.ts
@@ -1,23 +1,24 @@
 // {fact rule=session-fixation@v1.0 defects=1}
-var express = require("express");
-var passport = require("passport");
-var app = express();
+
+import express, { Express, Request, Response } from 'express'
+import passport from 'passport'
+var app: Express = express()
 function sessionFixationNoncompliant() {
   app.post(
     "/somepage",
     passport.authenticate("local", { failureRedirect: "/somepage" }),
-    function (req: any, res: { redirect: (arg0: string) => void }) {
+    function (req: Request, res: Response) {
       // Noncompliant: session.regenerate is absent.
-      res.redirect("/");
+      res.redirect("/")
     },
   );
 }
 // {/fact}
 
 // {fact rule=session-fixation@v1.0 defects=0}
-var express = require("express");
-var passport = require("passport");
-var app = express();
+import express, { Express, Request, Response } from 'express'
+import passport from 'passport'
+var app: Express = express()
 function sessionFixationCompliant() {
   app.post(
     "/somepage",
@@ -27,8 +28,8 @@ function sessionFixationCompliant() {
       res: { redirect: (arg0: string) => void },
     ) {
       // Compliant: session.regenerate is used
-      req.session.regenerate((err: any) => {});
-      res.redirect("/404");
+      req.session.regenerate((err: any) => {})
+      res.redirect("/404")
     },
   );
 }

--- a/src/typescript/detector/high/improper-certificate-validation/improper-certificate-validation.ts
+++ b/src/typescript/detector/high/improper-certificate-validation/improper-certificate-validation.ts
@@ -1,6 +1,5 @@
 // {fact rule=improper-certificate-validation@v1.0 defects=1}
-var tls = require("tls")
-var fs = require("fs")
+import tls from 'tls'
 
 function improperCertificateValidationNoncompliant() {
   var options = {
@@ -18,8 +17,8 @@ function improperCertificateValidationNoncompliant() {
 
 
 // {fact rule=improper-certificate-validation@v1.0 defects=0}
-var tls = require("tls")
-var fs = require("fs")
+import tls from 'tls'
+import fs from 'fs'
 
 function improperCertificateValidationCompliant() {
   var options = {

--- a/src/typescript/detector/high/insecure-cookie/insecure-cookie.ts
+++ b/src/typescript/detector/high/insecure-cookie/insecure-cookie.ts
@@ -1,7 +1,7 @@
 // {fact rule=insecure-cookie@v1.0 defects=1}
-var cookieSession = require("cookie-session");
-var express = require("express");
-var app = express();
+import express, { Express, Request, Response } from 'express'
+import cookieSession from 'cookie-session'
+var app: Express = express()
 function insecureCookieNoncompliant() {
   let session = app.use(
     cookieSession({
@@ -15,9 +15,9 @@ function insecureCookieNoncompliant() {
 // {/fact}
 
 // {fact rule=insecure-cookie@v1.0 defects=0}
-var cookieSession = require("cookie-session");
-var express = require("express");
-var app = express();
+import express, { Express, Request, Response } from 'express'
+import cookieSession from 'cookie-session'
+var app: Express = express()
 function insecureCookieCompliant() {
   // Compliant: by default `httpOnly` is set to true and thus makes cookie secure.
   let session = app.use(

--- a/src/typescript/detector/medium/improper-input-validation/improper-input-validation.ts
+++ b/src/typescript/detector/medium/improper-input-validation/improper-input-validation.ts
@@ -1,32 +1,32 @@
 // {fact rule=improper-input-validation@v1.0 defects=1}
-var express = require("express");
-var app = express();
+import express, { Express, Request, Response } from 'express'
+var app : Express = express()
 
 function improperInputValidationNoncompliant() {
   app.get(
     "/data/collection",
-    function (request: { params: { collection: any } }, response: any) {
+    function (request: Request, response: Response) {
       // Noncompliant: user input is not sanitized before use.
       var regex = RegExp(request.params.collection);
       regex.test(request.params.collection);
     },
-  );
+  )
 }
 //{/fact}
 
 // {fact rule=improper-input-validation@v1.0 defects=0}
-var express = require("express");
-var app = express();
-var escapeStringRegexp = require("escape-string-regexp");
+import express, { Express, Request, Response } from 'express'
+var app : Express = express()
+var escapeStringRegexp = require('escape-string-regexp')
 
 function improperInputValidationCompliant() {
   app.get(
     "/data/collection",
-    (request: { params: { collection: any } }, response: any) => {
+    (request: Request, response: Response) => {
       // Compliant: user input is sanitized before use.
-      var regex = RegExp(escapeStringRegexp(request.params.collection));
-      regex.test(request.params.collection);
+      var regex = RegExp(escapeStringRegexp(request.params.collection))
+      regex.test(request.params.collection)
     },
-  );
+  )
 }
 //{/fact}

--- a/src/typescript/detector/medium/insecure-cors-policy/insecure-cors-policy.ts
+++ b/src/typescript/detector/medium/insecure-cors-policy/insecure-cors-policy.ts
@@ -1,44 +1,23 @@
 // {fact rule=insecure-cors-policy@v1.0 defects=1}
-var express = require("express");
-var app = express();
-
+import express, { Express, Request, Response } from 'express'
+var app : Express = express()
 function insecureCorsPolicyNoncompliant() {
-  app.post(
-    "/users",
-    function (
-      req: { query: { origin: any } },
-      res: {
-        set: (
-          arg0: number,
-          arg1: { "Access-Control-Allow-Origin": any },
-        ) => void;
-      },
-    ) {
+  app.post( "/users", function ( req: Request, res: Response ) {
       const origin = req.query.origin;
       // Noncompliant: the Access-Control-Allow-Origin header is set to user-controlled any domain.
-      res.set(200, { "Access-Control-Allow-Origin": origin });
+      res.set(200, { "Access-Control-Allow-Origin": origin })
     },
   );
 }
 //{/fact}
 
 // {fact rule=insecure-cors-policy@v1.0 defects=0}
-var express = require("express");
-var app = express();
+import express, { Express, Request, Response } from 'express'
+var app : Express = express()
 function insecureCorsPolicyCompliant() {
-  app.post(
-    "/users",
-    function (
-      req: any,
-      res: {
-        set: (
-          arg0: number,
-          arg1: { "Access-Control-Allow-Origin": string },
-        ) => void;
-      },
-    ) {
+  app.post( "/users", function (req: Request, res: Response ) {
       // Compliant: the Access-Control-Allow-Origin header is set to allow only a specific list of trusted domains.
-      res.set(200, { "Access-Control-Allow-Origin": "trustedsite.com" });
+      res.set(200, { "Access-Control-Allow-Origin": "trustedsite.com" })
     },
   );
 }


### PR DESCRIPTION
1. Replace `require(..)` syntax with `import` statements.
2. Use the `Request` and `Response` objects in `express` wherever possible
