### PR TITLE
Add compliant and noncompliant examples of typescript/missing-authentication-for-critical-function-cdk@v1.0,typescript/aws-missing-encryption-cdk@v1.0

### DIFF
--- a/src/typescript/detector/high/aws-missing-encryption-cdk/aws-missing-encryption-cdk.ts
+++ b/src/typescript/detector/high/aws-missing-encryption-cdk/aws-missing-encryption-cdk.ts
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=aws-missing-encryption-cdk@v1.0 defects=1}
+import * as cdk from '@aws-cdk/core';
+import * as sqs from '@aws-cdk/aws-sqs';
+
+export class Stack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Noncompliant: Queue is not encrypted
+    const unencryptedQueue = new sqs.Queue(this, 'unecryptedQueue1')
+   
+  }
+}
+// {/fact}
+    
+// {fact rule=aws-missing-encryption-cdk@v1.0 defects=0}
+import * as cdk from '@aws-cdk/core';
+import * as sqs from '@aws-cdk/aws-sqs';
+import { Queue, QueueEncryption } from '@aws-cdk/aws-sqs';
+
+export class Stack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    // Compliant: Queue is encrypted
+    const encryptedQueue = new sqs.Queue(this, 'encryptedQueue', {
+        encryption: sqs.QueueEncryption.KMS_MANAGED
+    })
+   
+  }
+}
+// {/fact}

--- a/src/typescript/detector/high/missing-authentication-for-critical-function-cdk/missing-authentication-for-critical-function-cdk.ts
+++ b/src/typescript/detector/high/missing-authentication-for-critical-function-cdk/missing-authentication-for-critical-function-cdk.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+// {fact rule=missing-authentication-for-critical-function-cdk@v1.0 defects=1}
+import * as s3 from '@aws-cdk/aws-s3'
+import * as cdk from '@aws-cdk/core'
+import * as codebuild from '@aws-cdk/aws-codebuild'
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props)
+
+    // Noncompliant: Public project
+    const publicProject1 = new codebuild.Project(this, 'publicProject', {badge: true})
+}
+// {/fact}
+}
+
+// {fact rule=missing-authentication-for-critical-function-cdk@v1.0 defects=0}
+import * as s3 from '@aws-cdk/aws-s3'
+import * as cdk from '@aws-cdk/core'
+import * as codebuild from '@aws-cdk/aws-codebuild'
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props)
+    const bucket = new s3.Bucket()
+    // Compliant: Private project
+    const privateProject1 = codebuild.Project(this, 'privateProject1', {
+          source: codebuild.Source.s3({
+          bucket: bucket,
+          path: 'path/to/file.zip',
+        })
+    })
+
+}
+}
+// {/fact}


### PR DESCRIPTION
Add compliant and noncompliant examples of typescript/missing-authentication-for-critical-function-cdk@v1.0,typescript/aws-missing-encryption-cdk@v1.0