### PR TITLE
Add compliant and non-compliant examples for aws-insecure-transmission-cdk,use-of-default-credentials-cdk.

### DIFF
--- a/src/typescript/detector/high/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk.ts
+++ b/src/typescript/detector/high/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+// {fact rule=aws-insecure-transmission-cdk@v1.0 defects=1}
+import * as s3 from "@aws-cdk/aws-s3"
+import * as cdk from "@aws-cdk/core"
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) { 
+        super(scope, id, props);
+
+        // Noncompliant: SSL configuration missing
+        const bucket = new s3.Bucket(this, "s3-bucket")
+    }
+}
+// {/fact}
+
+// {fact rule=aws-insecure-transmission-cdk@v1.0 defects=0}
+import * as s3 from "@aws-cdk/aws-s3"
+import * as cdk from "@aws-cdk/core"
+
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) { 
+        super(scope, id, props);
+
+        // Compliant: SSL configuration present
+        const bucket = new s3.Bucket(this, "s3-bucket", { enforceSSL: true });
+    }
+}
+// {/fact}

--- a/src/typescript/detector/high/use_of_default_credentials_cdk/use_of_default_credentials_cdk.ts
+++ b/src/typescript/detector/high/use_of_default_credentials_cdk/use_of_default_credentials_cdk.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+// {fact rule=use-of-default-credentials-cdk@v1.0 defects=1}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from '@aws-cdk/core';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props)
+
+        // Noncompliant: Default master user name is used
+        new CfnCluster(Stack, 'rRedshiftCluster', {
+                                        masterUsername: 'awsuser',
+                                        masterUserPassword: 'use_a_secret_here',
+                                        clusterType: 'single-node',
+                                        dbName: 'bar',
+                                        nodeType: 'ds2.xlarge'
+                                    });
+    }
+}
+// {/fact}
+
+// {fact rule=use-of-default-credentials-cdk@v1.0 defects=0}
+import { CfnCluster } from 'aws-cdk-lib/aws-redshift';
+import { Stack } from 'aws-cdk-lib/core';
+import * as cdk from '@aws-cdk/core';
+
+export class CdkStarterStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props)
+
+        // Compliant: Custom master user name is used
+        new CfnCluster(Stack, 'rRedshiftCluster', {
+                                        masterUsername: 'notawsuser',
+                                        masterUserPassword: 'use_a_secret_here',
+                                        clusterType: 'single-node',
+                                        dbName: 'bar',
+                                        nodeType: 'ds2.xlarge',
+                                    });
+
+    }
+}
+// {/fact}


### PR DESCRIPTION
Add compliant and non-compliant examples for aws-insecure-transmission-cdk,use-of-default-credentials-cdk.
